### PR TITLE
Fix unmatched closing tag in terms section

### DIFF
--- a/index.html
+++ b/index.html
@@ -275,7 +275,6 @@
                     </div>
                 </div>
             </div>
-            </div>
             <div class="divider"></div>
         </section>
 


### PR DESCRIPTION
## Summary
- remove stray closing `div` in `index.html` terms section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842d451ad50832ebd7d7e4c831350d0